### PR TITLE
MAV-945 Update Dockerfile to node 12.16.1-alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
-FROM node:12.13.0-alpine
+FROM node:12.16.1-alpine
 
 ENV NODE_ENV production
 ENV NPM_CONFIG_LOGLEVEL info
 
-RUN npm install npm@6.4.1 -g
-
 # Setup source directory
-RUN mkdir /app
 WORKDIR /app
-COPY package.json package-lock.json /app/
+COPY package*.json ./
 RUN npm ci --production
 
 # Copy app to source directory
-COPY . /app
+COPY . .
 
 USER node
 CMD ["npm", "start"]


### PR DESCRIPTION
**Description**

This change stands to reduce the number of security vulnerabilites detected during the twistlock security vulnerability scan. [Here](https://agile-jira.pearson.com/browse/MAV-945) is the task number for the reference. 

**How Has This Been Tested?**

Still twist lock has not been implemented in Github. So I go through with the following workaround to test this.

- Build a docker image using the docker composer by using the Docker file. 
- Cloned the _**image-template**_ repository and buiild the container locally. By issuing `make build` command.
- Made the required twist lock environment configurations to start the local scan.
- Pointed locally build **_kubernetes-external-secrets_** docker image to twistlock.
- Issued the `make scan` command to start the scan
 
Following testings has been done to recognize the new changes in application level.

- Pushed the locally build  **_kubernetes-external-secrets_**  image into dockerhub
- Pointed docker image tag in the **_kubernetes-external-secrets_** deployment.
- Created a new external secret and checked and verified the output with the values in **ASM** 
